### PR TITLE
Add `MoldableRecord`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "purescript-prelude": "^4.1.0",
     "purescript-foldable-traversable": "^4.0.1",
-    "purescript-strings": "^4.0.0"
+    "purescript-strings": "^4.0.0",
+    "purescript-variant": "^6.0.1"
   },
   "devDependencies": {
     "purescript-console": "^4.1.0",

--- a/src/Data/Moldy.purs
+++ b/src/Data/Moldy.purs
@@ -7,7 +7,15 @@ import Data.Monoid.Dual (Dual(..))
 import Data.Monoid.Endo (Endo(..))
 import Data.Newtype (class Newtype, unwrap)
 import Data.String (CodePoint, toCodePointArray)
+import Data.Symbol (class IsSymbol, SProxy(..))
 import Data.Traversable (class Traversable)
+import Data.Variant (Variant)
+import Data.Variant (inj) as Variant
+import Prim.Row (class Cons) as Row
+import Prim.RowList (Cons, Nil) as RowList
+import Prim.RowList (class RowToList, kind RowList)
+import Record (get) as Record
+import Type.Data.RowList (RLProxy(..))
 
 -- | A Moldable type `t` is a monomorphic foldable structure with
 -- | elements of type `e`.
@@ -55,6 +63,34 @@ instance moldableFoldable :: Foldable t => Moldable (Molded t e) e where
 -- TODO: make more efficient
 instance moldableString :: Moldable String CodePoint where
   moldMap f = foldMap f <<< toCodePointArray
+  moldl f = moldlDefault f
+  moldr f = moldrDefault f
+
+newtype MoldableRecord r = MoldableRecord { | r }
+
+class MoldMapRecord (list :: RowList) (row :: # Type) where
+  moldMapRecord :: forall m. Monoid m =>
+    RLProxy list -> (Variant row -> m) -> MoldableRecord row -> m
+
+instance moldableRecordNil :: MoldMapRecord RowList.Nil row where
+  moldMapRecord _ _ _ = mempty
+
+instance moldableRecordCons
+  :: (Row.Cons sym a r' row,
+      IsSymbol sym,
+      MoldMapRecord tail row)
+  => MoldMapRecord (RowList.Cons sym a tail) row where
+  moldMapRecord _ f mr@(MoldableRecord r) = f variant <> moldMapRecord tail f mr
+    where
+      sym = SProxy :: SProxy sym
+      tail = RLProxy :: RLProxy tail
+      variant = Variant.inj sym (Record.get sym r)
+
+instance moldableRecord
+  :: (RowToList r rl,
+      MoldMapRecord rl r)
+  => Moldable (MoldableRecord r) (Variant r) where
+  moldMap f = moldMapRecord (RLProxy :: RLProxy rl) f
   moldl f = moldlDefault f
   moldr f = moldrDefault f
 

--- a/src/Data/Moldy.purs
+++ b/src/Data/Moldy.purs
@@ -72,10 +72,10 @@ class MoldMapRecord (list :: RowList) (row :: # Type) where
   moldMapRecord :: forall m. Monoid m =>
     RLProxy list -> (Variant row -> m) -> MoldableRecord row -> m
 
-instance moldableRecordNil :: MoldMapRecord RowList.Nil row where
+instance moldMapRecordNil :: MoldMapRecord RowList.Nil row where
   moldMapRecord _ _ _ = mempty
 
-instance moldableRecordCons
+instance moldMapRecordCons
   :: (Row.Cons sym a r' row,
       IsSymbol sym,
       MoldMapRecord tail row)


### PR DESCRIPTION
* Should I move this to a separate module (In such a case I could rename this `newtype` to just `Record.Moldable` too) or leave it here?

* I've tried to be consistent with coding style of other libs (I've found type class constraint formatting in _type-lang_, `where` indentation in _filterable_). 